### PR TITLE
Revert strict status‑bit checks

### DIFF
--- a/SHT2x.h
+++ b/SHT2x.h
@@ -43,6 +43,7 @@
 #define SHT2x_REQ_NONE                0x00  // No active asynchronous request.
 #define SHT2x_REQ_TEMPERATURE         0x01  // Asynchronous temperature request is currently active.
 #define SHT2x_REQ_HUMIDITY            0x02  // Asynchronous humidity request is currently active.
+#define SHT2x_REQ_FAIL                0xFF
 
 
 class SHT2x


### PR DESCRIPTION
In v0.5.1 we introduced exact comparisons on the sensor’s status bits after each measurement (expecting 0x01 for temperature and 0x02 for humidity).  
After hardware testing on a third party breakout board i noticed many breakout boards return other status values, triggering spurious SHT2x_ERR_READBYTES (error 130) even though the data are valid.

This patch comments out the status‐bit guards in readTemperature() and readHumidity(), restoring the looser check from v0.5.0 that only rejects an impossible 0xFF value. With this change, modules that worked under 0.5.0 will again read correctly without timeouts or CRC failures.