### PR TITLE
Fix: Make sure sensor is ready before issuing first temp/hum request command

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ void loop() {
 }
 ```
 
+**Waiting until the device is ready:**
+
+These sensors typically need a bit of time to start up before they can accept commands. The SHT21, for instance, requires up to 15ms after it's been powered up. In many programs, the delay that the Arduino framework introduces between your `setup()` and `loop()` functions is sufficient, but if you intend to request your first reading in `setup()` immediately after calling `begin()`, the request may fail. If `requestTemperature()` or `requestHumidity()` returns false and the error code returned from `getError()` is `0x81` (`SHT2x_ERR_WRITECMD`), this may be a sign that the sensor isn't ready.
+
+To work around this, introduce a short delay after calling `begin()` and before requesting a reading. 15ms is probably more than sufficient, although this hasn't been tested extensively.
+
 #### Heater Functions
 
 The built-in heater can be used to test the sensor or to drive off condensation.

--- a/examples/SHT2x_demo_async/SHT2x_demo_async.ino
+++ b/examples/SHT2x_demo_async/SHT2x_demo_async.ino
@@ -27,6 +27,8 @@ void setup()
   Serial.print(stat, HEX);
   Serial.println();
 
+  // Wait for the sensor to be ready to start accepting commands.
+  delay(15);
   sht.requestTemperature();
 }
 

--- a/examples/SHT2x_demo_async_HT/SHT2x_demo_async_HT.ino
+++ b/examples/SHT2x_demo_async_HT/SHT2x_demo_async_HT.ino
@@ -36,6 +36,8 @@ void setup()
   Serial.print(stat, HEX);
   Serial.println();
 
+  // Wait for the sensor to be ready to start accepting commands.
+  delay(15);
   sht.requestTemperature();
 }
 


### PR DESCRIPTION
Closes #37 . Adds a note in the README and adds a delay to the async example sketches.